### PR TITLE
fix: Differentiate port based on VISUALIZER_TYPE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && \
     apk add --no-cache curl && \
     apk cache clean
 
+COPY --chmod=700 ./healthcheck.sh /healthcheck
 COPY ./www /www
 COPY ./target/x86_64-unknown-linux-musl/release/docker-swarm-visualizer-rs /docker-swarm-visualizer-rs
 
@@ -15,6 +16,6 @@ HEALTHCHECK \
     --timeout=1s \
     --start-period=30s \
     --retries=3 \
-    CMD curl -f http://localhost:3500/healthcheck || exit 1
+    CMD /healthcheck || exit 1
 
 CMD ["/docker-swarm-visualizer-rs"]

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+case "${VISUALIZER_TYPE:-}" in
+    "manager")
+        PORT=9510;;
+    "agent")
+        PORT=9511;;
+    *)
+        PORT=3500;;
+esac
+
+curl -sf http://localhost:${PORT}/healthcheck || exit 1


### PR DESCRIPTION
My last MR introduced a bug, sorry about this - I overlooked that the healthcheck port needs to differentiate based on the `VISUALIZER_TYPE`. This adds the check by moving the healthcheck to a simple script.